### PR TITLE
json should have a kind field so we know what type it is.

### DIFF
--- a/DOC/sample_data/multiple_transactions.json
+++ b/DOC/sample_data/multiple_transactions.json
@@ -1,5 +1,6 @@
 [
   {
+  "kind": "transaction",
   "amount": 1234.56,
   "flow": "in",
   "payee": "State of Nebraska",
@@ -12,6 +13,7 @@
   ]
 },
 {
+  "kind": "transaction",
   "amount": 142.86,
   "flow": "out",
   "payee": "Wooly Canada",
@@ -26,6 +28,7 @@
   ]
 },
 {
+  "kind": "transaction",
   "amount": 72.11,
   "flow": "out",
   "payee": "Delicious Canada",

--- a/DOC/sample_data/single_transaction.json
+++ b/DOC/sample_data/single_transaction.json
@@ -1,4 +1,5 @@
 {
+  "kind": "transaction",
   "amount": 142.86,
   "flow": "out",
   "payee": "Wooly Canada",


### PR DESCRIPTION
This is a nice to have that I think we'll like having in the long run.  I do not know if there is a traditional way of doing this.  Let's just put a kind field near the top of each object.